### PR TITLE
Cannot find module 'lodash'

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "type": "git",
     "url": "https://github.com/michellocana/babel-plugin-jsx-auto-test-id"
   },
+  "dependencies": {
+    "lodash": "^4.17.15"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
@@ -29,7 +32,6 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "jest": "^24.9.0",
-    "lodash": "^4.17.15",
     "react": "^16.11.0",
     "react-test-renderer": "^16.11.0"
   }


### PR DESCRIPTION
loadash is a dependency required by `src/index.js`
```
Error: [BABEL]: Cannot find module 'lodash'
Require stack:
- <project>\node_modules\babel-plugin-jsx-auto-test-id\src\index.js
- <project>\node_modules\@babel\...
- ...
```

workaround: explicit install `lodash` in your project